### PR TITLE
Add Analytics section to app-config.cfg.example

### DIFF
--- a/config/app-config.cfg.example
+++ b/config/app-config.cfg.example
@@ -32,3 +32,7 @@ email =
 host =
 username =
 password =
+
+[Analytics]
+enabled = false
+email = 


### PR DESCRIPTION
The app expects the `[Analytics]` section, as in `app-config-test.cfg.example`.