### PR TITLE
Change file extension from .ep to .kmp

### DIFF
--- a/lib/Api/Handler/IO/IOHandler.hs
+++ b/lib/Api/Handler/IO/IOHandler.hs
@@ -16,7 +16,7 @@ exportA = do
   eitherDto <- lift $ getPackageWithEventsById pkgId
   case eitherDto of
     Right dto -> do
-      let cdHeader = "attachment;filename=" ++ pkgId ++ ".ep"
+      let cdHeader = "attachment;filename=" ++ pkgId ++ ".kmp"
       addHeader "Content-Disposition" (pack cdHeader)
       addHeader "Content-Type" (pack "application/octet-stream")
       raw $ encode dto


### PR DESCRIPTION
It gives more sense to provide file with `.kmp` (knowledge model package) instead of `.ep` (events package?) as we already changed the naming in the Wizard while ago...