### PR TITLE
Fix export DMP in ODT and PDF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:14.04
 WORKDIR /dsw
 
 # Install necessary libraries
-RUN apt-get update && apt-get update && apt-get -qq -y install libmemcached-dev ca-certificates wkhtmltopdf
+RUN apt-get update && apt-get update && apt-get -qq -y install libmemcached-dev ca-certificates wget gdebi-core
+RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.trusty_amd64.deb && gdebi -n wkhtmltox_0.12.5-1.trusty_amd64.deb
 
 # Add built exectutable binary
 ADD .stack-work/install/x86_64-linux/lts-9.11/8.0.2/bin/dsw-server /dsw/dsw-server

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - vendor/bson-generic
-  - fromhtml-0.1.0.0
+  - fromhtml-0.1.0.1
   - pandoc-2.2.1
   - cmark-gfm-0.1.3
   - doctemplates-0.2.2.1


### PR DESCRIPTION
- ODT: Use of newer version of fromhtml (0.1.0.1)
- PDF: updated Dockerfile to install wkhtmltopdf 0.12.5 (please check that...)

Should solve https://github.com/DataStewardshipWizard/dsw-common/issues/90