### PR TITLE
Use Pandoc externally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /dsw
 # Install necessary libraries
 RUN apt-get update && apt-get -qq -y install libmemcached-dev ca-certificates wget gdebi-core
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.trusty_amd64.deb && gdebi -n wkhtmltox_0.12.5-1.trusty_amd64.deb
+RUN wget https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-1-amd64.deb && gdebi -n pandoc-2.2.1-1-amd64.deb
 
 # Add built exectutable binary
 ADD .stack-work/install/x86_64-linux/lts-9.11/8.0.2/bin/dsw-server /dsw/dsw-server

--- a/docs/Contribute.md
+++ b/docs/Contribute.md
@@ -11,6 +11,7 @@ Go though this whole document and you will be ready.
 - Docker
 - MongoDB
 - wkhtmltopdf (recommended 0.12.5 or higher) - *for exports in PDF format only*
+- pandoc (recommended 2.1 or higher) - *for exports in non HTML/PDF formats only*
 
 ## How to setup the application for a local run?
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,24 +41,10 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - vendor/bson-generic
-  - fromhtml-0.1.0.1
-  - pandoc-2.2.1
-  - cmark-gfm-0.1.3
-  - doctemplates-0.2.2.1
-  - hslua-0.9.5.2
-  - hslua-module-text-0.1.2.1
-  - pandoc-types-1.17.5.1
-  - skylighting-0.7.2
-  - tagsoup-0.14.6
-  - texmath-0.11.0.1
-  - ansi-terminal-0.8.0.4
-  - skylighting-core-0.7.2
-
+  - fromhtml-0.1.0.2
 
 # Override default flag values for local packages and extra-deps
-flags:
-  pandoc:
-    embed_data_files: true
+# flags: {}
 
 # Extra package databases containing global packages
 extra-package-dbs: []


### PR DESCRIPTION
Instead of using Pandoc's Haskell API, let's use new version (0.1.0.2) of FromHTML that is not dependent of Pandoc directly but calls it as external process. Thus binary Pandoc needs to be installed in the Docker image. 