### PR TITLE
DMP export fix PDF and HTML charset

### DIFF
--- a/lib/Service/DataManagementPlan/Templates/Html.hs
+++ b/lib/Service/DataManagementPlan/Templates/Html.hs
@@ -36,6 +36,7 @@ fkm2html km =
   H.docTypeHtml $ do
     H.head $ do
       H.title textTitle
+      H.meta ! A.charset (H.stringValue "utf-8")
       H.style . H.toHtml $ dmpCSS
     H.body $
       H.article ! A.class_ "dmp" $ do

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - vendor/bson-generic
-  - fromhtml-0.1.0.2
+  - fromhtml-0.1.0.3
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Fixing:

- problems with PDF generation (new version of [FromHTML](https://github.com/MarekSuchanek/FromHTML))
- missing charset meta in HTML, causing that in some browsers special Unicode characters are not displayed correctly (https://github.com/DataStewardshipWizard/dsw-common/issues/95)