### PR TITLE
New FromHTML handling exceptions

### DIFF
--- a/lib/Localization.hs
+++ b/lib/Localization.hs
@@ -77,7 +77,7 @@ _ERROR_SERVICE_USER__REQUIRED_ADMIN_ROLE_OR_HASH_IN_QUERY_PARAMS =
 _ERROR_SERVICE_USER__REQUIRED_HASH_IN_QUERY_PARAMS = "A hash query param has to be provided"
 
 -- DataManagementPlan
-_ERROR_SERVICE_DMP__TRANSFORMATION_FAILED = "Couldn't transform to desired document format"
+_ERROR_SERVICE_DMP__TRANSFORMATION_FAILED err = "Couldn't transform to desired document format: " ++ err
 
 _ERROR_SERVICE_DMP__UKNOWN_FORMAT = "Unprocessable DMP format"
 

--- a/lib/Service/DataManagementPlan/Templates/FormatMapper.hs
+++ b/lib/Service/DataManagementPlan/Templates/FormatMapper.hs
@@ -20,6 +20,9 @@ type DMPExportType = FromHTML.ExportType
 strToBSL :: String -> BSL.ByteString
 strToBSL = BSL.fromStrict . E.encodeUtf8 . T.pack
 
+bsToStr :: BS.ByteString -> String
+bsToStr = T.unpack . E.decodeUtf8
+
 toHTML :: DataManagementPlanDTO -> BSL.ByteString
 toHTML = strToBSL . mkHTMLString
 
@@ -29,9 +32,9 @@ toFormat format = toType (formatToType format)
     toType :: Maybe DMPExportType -> DataManagementPlanDTO -> Either AppError BSL.ByteString
     toType (Just eType) dmp = handleResult . FromHTML.fromHTML eType . mkHTMLString $ dmp
     toType _ _ = Left . GeneralServerError $ _ERROR_SERVICE_DMP__UKNOWN_FORMAT
-    handleResult :: Maybe BS.ByteString -> Either AppError BSL.ByteString
-    handleResult (Just result) = Right . BSL.fromStrict $ result
-    handleResult _ = Left . GeneralServerError $ _ERROR_SERVICE_DMP__TRANSFORMATION_FAILED
+    handleResult :: Either BS.ByteString BS.ByteString -> Either AppError BSL.ByteString
+    handleResult (Right result) = Right . BSL.fromStrict $ result
+    handleResult (Left err) = Left . GeneralServerError $ _ERROR_SERVICE_DMP__TRANSFORMATION_FAILED (bsToStr err)
 
 mkHTMLString :: DataManagementPlanDTO -> String
 mkHTMLString dmp = dmp2html $ dmp ^. filledKnowledgeModel

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,7 +42,7 @@ packages:
 extra-deps:
   - vendor/bson-generic
   - vendor/mongoDB-migration
-  - fromhtml-0.1.0.4
+  - fromhtml-1.0.0
   - persistent-mongoDB-2.8.0
   - ConfigFile-1.1.4
   - pwstore-fast-2.4.4


### PR DESCRIPTION
- Solves encoding problems with launching subprocesses in Docker (https://github.com/MarekSuchanek/FromHTML/commit/09f2cc9c0ea01aa3f348b1ca382e1ceab7af0954)
- Enables displaying error details (https://github.com/MarekSuchanek/FromHTML/commit/6842076a6a548d313b69e81bff9ec2b60fa7ad8f)

Tested with dsw-server built in Docker with the Docker file in this repo :heavy_check_mark: 