### PR TITLE
Update LTS Haskell

### DIFF
--- a/lib/Service/Feedback/Connector/GitHub/GitHubConnector.hs
+++ b/lib/Service/Feedback/Connector/GitHub/GitHubConnector.hs
@@ -42,14 +42,14 @@ instance Connector AppContextM where
           GI.NewIssue
           { newIssueTitle = T.pack title
           , newIssueBody = Just . T.pack $ content
-          , newIssueAssignee = Nothing
+          , newIssueAssignees = V.empty
           , newIssueMilestone = Nothing
           , newIssueLabels = Just . V.fromList $ [(packToName packageId), (packToName . U.toString $ questionUuid)]
           }
     let request = GH.createIssueR (packToName fOwner) (packToName fRepo) newIssue
     eIssue <- liftIO $ GH.executeRequest (GA.OAuth . BS.pack $ fToken) request
     case eIssue of
-      Right issue -> return . Right . GI.issueNumber $ issue
+      Right issue -> return . Right . GD.unIssueNumber . GI.issueNumber $ issue
       Left error -> do
         logError . show $ error
         return . Left . HttpClientError $ _ERROR_HTTP_CLIENT__REQUEST_FAILED "GitHub" "Create issue"

--- a/lib/Service/Feedback/Connector/GitHub/GitHubMapper.hs
+++ b/lib/Service/Feedback/Connector/GitHub/GitHubMapper.hs
@@ -3,13 +3,14 @@ module Service.Feedback.Connector.GitHub.GitHubMapper where
 import Data.Maybe
 import qualified Data.Text as T
 import qualified GitHub.Data.Issues as GI
+import qualified GitHub.Data.Definitions as GD
 
 import Model.Feedback.SimpleIssue
 
 toSimpleIssue :: GI.Issue -> SimpleIssue
 toSimpleIssue i =
   SimpleIssue
-  { _simpleIssueIssueId = GI.issueNumber i
+  { _simpleIssueIssueId = GD.unIssueNumber . GI.issueNumber $ i
   , _simpleIssueTitle = T.unpack $ GI.issueTitle i
   , _simpleIssueContent = fromMaybe "" (T.unpack <$> GI.issueBody i)
   }

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-12.0
+resolver: lts-13.10
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -48,6 +48,10 @@ extra-deps:
   - pwstore-fast-2.4.4
   - pretty-terminal-0.1.0.0
   - ginger-0.8.1.0
+  - HaskellNet-SSL-0.3.4.1@sha256:3ca14dd69460a380cf69aed40654fb10c4c03e344632b6a9986568c87feda157
+  - github-0.21@sha256:9d88c84e308723e314069f91c70c0f3fdad6d18976f185f1ae672ce8eee30547
+  - http-api-data-0.3.10@sha256:13e1ed2514ec7a857454f472604fc6bf9616d908d2de7202c2507e413029c907
+  - jwt-0.9.0@sha256:82df51e48d2c7a6773bac7cd0f99f221107e7124db5d118f828dc08af025edee
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
This PR updates stack resolver to LTS 13.10 (GHC 8.6.3). Small migration was needed JWT and GitHub modules because of API change.