### PR TITLE
Update LTS Haskell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   # 2. Configure stack to use the system GHC installation
   - stack config set system-ghc --global true
-  - export PATH=/opt/ghc/ghc-8.6.3/bin:$PATH
+  - export PATH=/opt/ghc/ghc-8.6.4/bin:$PATH
   # 3. Init Application Config
   - cp config/app-config.cfg.example config/app-config.cfg
   - cp config/app-config-test.cfg.example config/app-config-test.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   # 2. Configure stack to use the system GHC installation
   - stack config set system-ghc --global true
-  - export PATH=/opt/ghc/ghc-8.4.3/bin:$PATH
+  - export PATH=/opt/ghc/ghc-8.6.3/bin:$PATH
   # 3. Init Application Config
   - cp config/app-config.cfg.example config/app-config.cfg
   - cp config/app-config-test.cfg.example config/app-config-test.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkh
 RUN wget https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-1-amd64.deb && gdebi -n pandoc-2.2.1-1-amd64.deb
 
 # Add built exectutable binary
-ADD .stack-work/install/x86_64-linux/lts-13.10/8.6.3/bin/dsw-server /dsw/dsw-server
+ADD .stack-work/install/x86_64-linux/lts-13.12/8.6.4/bin/dsw-server /dsw/dsw-server
 
 # Add configs
 ADD config/app-config.cfg.example /dsw/config/app-config.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkh
 RUN wget https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-1-amd64.deb && gdebi -n pandoc-2.2.1-1-amd64.deb
 
 # Add built exectutable binary
-ADD .stack-work/install/x86_64-linux/lts-12.0/8.4.3/bin/dsw-server /dsw/dsw-server
+ADD .stack-work/install/x86_64-linux/lts-13.10/8.6.3/bin/dsw-server /dsw/dsw-server
 
 # Add configs
 ADD config/app-config.cfg.example /dsw/config/app-config.cfg

--- a/lib/Service/Feedback/Connector/GitHub/GitHubConnector.hs
+++ b/lib/Service/Feedback/Connector/GitHub/GitHubConnector.hs
@@ -42,14 +42,14 @@ instance Connector AppContextM where
           GI.NewIssue
           { newIssueTitle = T.pack title
           , newIssueBody = Just . T.pack $ content
-          , newIssueAssignee = Nothing
+          , newIssueAssignees = V.empty
           , newIssueMilestone = Nothing
           , newIssueLabels = Just . V.fromList $ [(packToName packageId), (packToName . U.toString $ questionUuid)]
           }
     let request = GH.createIssueR (packToName fOwner) (packToName fRepo) newIssue
     eIssue <- liftIO $ GH.executeRequest (GA.OAuth . BS.pack $ fToken) request
     case eIssue of
-      Right issue -> return . Right . GI.issueNumber $ issue
+      Right issue -> return . Right . GD.unIssueNumber . GI.issueNumber $ issue
       Left error -> do
         logError . show $ error
         return . Left . HttpClientError $ _ERROR_HTTP_CLIENT__REQUEST_FAILED "GitHub" "Create issue"

--- a/lib/Service/Feedback/Connector/GitHub/GitHubMapper.hs
+++ b/lib/Service/Feedback/Connector/GitHub/GitHubMapper.hs
@@ -3,13 +3,14 @@ module Service.Feedback.Connector.GitHub.GitHubMapper where
 import Data.Maybe
 import qualified Data.Text as T
 import qualified GitHub.Data.Issues as GI
+import qualified GitHub.Data.Definitions as GD
 
 import Model.Feedback.SimpleIssue
 
 toSimpleIssue :: GI.Issue -> SimpleIssue
 toSimpleIssue i =
   SimpleIssue
-  { _simpleIssueIssueId = GI.issueNumber i
+  { _simpleIssueIssueId = GD.unIssueNumber . GI.issueNumber $ i
   , _simpleIssueTitle = T.unpack $ GI.issueTitle i
   , _simpleIssueContent = fromMaybe "" (T.unpack <$> GI.issueBody i)
   }

--- a/package.yaml
+++ b/package.yaml
@@ -11,7 +11,7 @@ license-file: LICENSE.md
 homepage: https://github.com/DataStewardshipWizard/dsw-server
 git: git@github.com:DataStewardshipWizard/dsw-server.git
 bug-reports: https://github.com/DataStewardshipWizard/dsw-common/issues
-tested-with: GHC==7.6.* GHC==7.8.*
+tested-with: GHC==8.6.*
 data-files:
   - config/app-config.cfg
   - config/build-info.cfg

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-12.0
+resolver: lts-13.10
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -49,6 +49,10 @@ extra-deps:
   - pretty-terminal-0.1.0.0
   - ginger-0.8.1.0
   - roman-numerals-0.5.1.5
+  - HaskellNet-SSL-0.3.4.1
+  - github-0.21
+  - http-api-data-0.3.10
+  - jwt-0.9.0
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-13.10
+resolver: lts-13.12
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This PR updates stack resolver to LTS 13.10 (GHC 8.6.3). Small migration was needed JWT and GitHub modules because of API change. Replaces #48 due to CI errors.