### PR TITLE
Upgrade to Ubuntu 16.04 (Xenial Xerus)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: false
-
+dist: xenial
 language: generic
+
+addons:
+  apt:
+    packages:
+      - rabbitmq-server
 
 services:
   - mongodb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 WORKDIR /dsw
 
 # Install necessary libraries
-RUN apt-get update && apt-get -qq -y install libmemcached-dev ca-certificates wget gdebi-core curl
+RUN apt-get update && apt-get -qq -y install libmemcached-dev ca-certificates netbase wget gdebi-core curl
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.trusty_amd64.deb && gdebi -n wkhtmltox_0.12.5-1.trusty_amd64.deb
 RUN wget https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-1-amd64.deb && gdebi -n pandoc-2.2.1-1-amd64.deb
 


### PR DESCRIPTION
Since the support of Ubuntu 14.04 (Trusty Tahr) ends now - April 2019 (see https://wiki.ubuntu.com/Releases), we need new version asap because of repositories etc. Other improvements will be done as part of [DSW-267](https://ds-wizard.atlassian.net/browse/DSW-267).

This was tested in my dummy fork: https://github.com/MarekSuchanek/dsw-server

(Sadly no 18.04 in Travis CI, so we cannot be happy till 2023, just 2021 :cry:)