### PR TITLE
[DSW-288] Travis build review and speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ install:
   # 1. Download, unpack, and check the stack executable
   - mkdir -p ~/.local/bin
   - export PATH=$HOME/.local/bin:$PATH
-  - travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-  - stack --version
+  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   # 2. Init Application Config
   - cp config/app-config.cfg.example config/app-config.cfg
   - cp config/app-config-test.cfg.example config/app-config-test.cfg
@@ -49,7 +48,7 @@ jobs:
   include:
     - stage: build
       script:
-        # 1. Init & check testing Mongo Database
+        # 1. Init and check testing Mongo Database
         - mongo dsw-server-test --eval 'db.collection.find()'
         # 2. Create build info inside application
         - cd scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,11 @@ stages:
   - tag
 
 env:
-  - PRIVATE_IMAGE="$REGISTRY/elixir/dsw-server" IMAGE="datastewardshipwizard/server" IMAGE_TAG="$PRIVATE_IMAGE:$TRAVIS_COMMIT" IMAGE_TAG_DEVELOP="$IMAGE:develop" IMAGE_TAG_LATEST="$IMAGE:latest"
+  - PRIVATE_IMAGE="$REGISTRY/elixir/dsw-server" \
+    IMAGE="datastewardshipwizard/server" \
+    IMAGE_TAG="$PRIVATE_IMAGE:$TRAVIS_COMMIT" \
+    IMAGE_TAG_DEVELOP="$IMAGE:develop" \
+    IMAGE_TAG_LATEST="$IMAGE:latest"
 
 cache:
   timeout: 600
@@ -26,42 +30,45 @@ cache:
   - .stack-work
 
 install:
-  # 1. Download and unpack the stack executable
+  # 1. Download, unpack, and check the stack executable
   - mkdir -p ~/.local/bin
   - export PATH=$HOME/.local/bin:$PATH
-  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-  # 2. Configure stack to use the system GHC installation
-  - stack config set system-ghc --global true
-  - export PATH=/opt/ghc/ghc-8.6.4/bin:$PATH
-  # 3. Init Application Config
+  - travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  - stack --version
+  # 2. Init Application Config
   - cp config/app-config.cfg.example config/app-config.cfg
   - cp config/app-config-test.cfg.example config/app-config-test.cfg
 
 before_script:
-  # 1. Log to both public and our private Docker Registry
+  # 1. Log to public Docker Hub
   - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+  # 2. Log to private Docker Registry
   - docker login -u "$REGISTRY_USERNAME" -p "$REGISTRY_PASSWORD" "$REGISTRY"
 
 jobs:
   include:
     - stage: build
       script:
-        # 1. Init testing Mongo Database
+        # 1. Init & check testing Mongo Database
         - mongo dsw-server-test --eval 'db.collection.find()'
         # 2. Create build info inside application
         - cd scripts
         - ./build-info.sh
         - cd ..
         # 3. Build and Test Application
-        - stack --no-terminal --skip-ghc-check test
+        - stack build --no-terminal --skip-ghc-check --test
         # 4. Build Docker Image
-        - docker pull $IMAGE_TAG_LATEST
-        - docker build --pull --cache-from $IMAGE_TAG_LATEST -t $IMAGE_TAG .
+        - docker pull $IMAGE_TAG_DEVELOP
+        - docker build --cache-from $IMAGE_TAG_DEVELOP -t $IMAGE_TAG .
         - docker push $IMAGE_TAG
 
     - stage: tag
       if: (branch = develop) AND (NOT (type IN (pull_request)))
+      addons: false
+      services: false
+      cache: false
       before_install: false
+      install: false
       script:
         - docker pull $IMAGE_TAG
         - docker image tag $IMAGE_TAG $IMAGE_TAG_DEVELOP
@@ -69,7 +76,11 @@ jobs:
 
     - stage: tag
       if: (branch = master) AND (NOT (type IN (pull_request)))
+      addons: false
+      services: false
+      cache: false
       before_install: false
+      install: false
       script:
         - docker pull $IMAGE_TAG
         - docker image tag $IMAGE_TAG $IMAGE_TAG_LATEST
@@ -77,7 +88,11 @@ jobs:
 
     - stage: tag
       if: tag =~ ^v
+      addons: false
+      services: false
+      cache: false
       before_install: false
+      install: false
       env:
         - PRIVATE_IMAGE="$REGISTRY/elixir/dsw-server"
         - IMAGE="datastewardshipwizard/server"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ HEALTHCHECK --interval=5m --timeout=10s \
 # Install necessary libraries
 RUN apt-get update && apt-get -qq -y install libmemcached-dev ca-certificates netbase wget gdebi-core curl
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.trusty_amd64.deb && gdebi -n wkhtmltox_0.12.5-1.trusty_amd64.deb
-RUN wget https://github.com/jgm/pandoc/releases/download/2.7.1/pandoc-2.7.1-1-amd64.deb && gdebi -n pandoc-2.7.1-1-amd64.deb
+RUN wget https://github.com/jgm/pandoc/releases/download/2.7.2/pandoc-2.7.2-1-amd64.deb && gdebi -n pandoc-2.7.2-1-amd64.deb
 
 # Add built exectutable binary
 ADD .stack-work/install/x86_64-linux/lts-13.12/8.6.4/bin/dsw-server /dsw/dsw-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,22 @@ FROM ubuntu:16.04
 
 WORKDIR /dsw
 
+HEALTHCHECK --interval=5m --timeout=10s \
+  CMD curl -f http://localhost:3000/ || exit 1
+
 # Install necessary libraries
 RUN apt-get update && apt-get -qq -y install libmemcached-dev ca-certificates netbase wget gdebi-core curl
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.trusty_amd64.deb && gdebi -n wkhtmltox_0.12.5-1.trusty_amd64.deb
-RUN wget https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-1-amd64.deb && gdebi -n pandoc-2.2.1-1-amd64.deb
+RUN wget https://github.com/jgm/pandoc/releases/download/2.7.1/pandoc-2.7.1-1-amd64.deb && gdebi -n pandoc-2.7.1-1-amd64.deb
 
 # Add built exectutable binary
 ADD .stack-work/install/x86_64-linux/lts-13.12/8.6.4/bin/dsw-server /dsw/dsw-server
 
-# Add configs
-ADD config/app-config.cfg.example /dsw/config/app-config.cfg
-ADD config/build-info.cfg /dsw/config/build-info.cfg
+# Add templates
 ADD templates /dsw/templates
 
-HEALTHCHECK --interval=5m --timeout=10s \
-  CMD curl -f http://localhost:3000/ || exit 1
+# Add configs
+ADD config/app-config.cfg /dsw/config/app-config.cfg
+ADD config/build-info.cfg /dsw/config/build-info.cfg
 
 CMD ["./dsw-server"]


### PR DESCRIPTION
- Updated from Ubuntu Trusty (14.04) to Ubuntu Xenial (16.04) - pushed earlier bcs of emergency
- Updated `pandoc` (tested), no new version of `wkhtmltopdf`
- Downloading latest `stack` instead of fixed 1.9.3 and printing version to log
- Speedup of “tag” job thanks to skipping unnecessary cache, addons, services, and install
- Speedup of “build” job by fixing Docker `--cache-from` (develop instead of latest and no `--pull`) 
- Reorganized Dockerfile for better caching of layers
- Improved a bit the readability of `.travis.yml`

