### PR TITLE
[DSW-423] Questionnaire name in DMP template

### DIFF
--- a/templates/dmp/root.css
+++ b/templates/dmp/root.css
@@ -49,6 +49,12 @@ header > h1 > div.headline {
   margin-left: 1rem;
 }
 
+header > h1 > div.headline > span.km-name {
+  color: #868e96;
+  font-size: 75%;
+  font-style: italic;
+}
+
 header > h1 > svg {
   float: left;
   height: 40px;

--- a/templates/dmp/root.html.j2
+++ b/templates/dmp/root.html.j2
@@ -15,7 +15,10 @@
   <header>
     <h1>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 204 153"><path d="M151,113.37,137.24,89.08l-24.67-7.25,19-2.76L113.81,47.7,95.94,37.89l17.18,2.85,37.53,5.7L94.59,1.33c-2.76-2.67-6.88-1.47-8.32,2.44l-14.4,55,20,3.36L69.71,67,57.32,114.31l36.85,5.2-41.56,6.63L.66,152.1s34.15-1.54,45.76-3.16c44-6.14,76.34-6.76,120.36-13.54,7.71-1.19,37.56-20.62,37.56-20.62Z" style="fill:#333"/></svg>
-      <div class="headline">{{km.name}}</div>
+      <div class="headline">
+        <span class="questionnaire-name">{{dmp.questionnaireName}}</span><br>
+        <span class="km-name">{{km.name}}</span>
+      </div>
     </h1>
     <dl>
       <dt>Organization</dt>


### PR DESCRIPTION
Simply added as heading and KM name is now "subheading" (75% size, gray color & italic to match the table below).