### PR TITLE
[DSW-427] Include full package ID in DMP template

### DIFF
--- a/templates/dmp/root.css
+++ b/templates/dmp/root.css
@@ -90,6 +90,11 @@ dl dd {
   font-style: italic;
 }
 
+dl dt > span.package-id {
+  font-family: monospace;
+  font-style: normal;
+}
+
 /**************************/
 
 table {

--- a/templates/dmp/root.html.j2
+++ b/templates/dmp/root.html.j2
@@ -25,7 +25,7 @@
         <dd>{{dmp.createdBy.name}} {{dmp.createdBy.surname}} (<a href="mailto:{{dmp.user.email}}">{{dmp.createdBy.email}}</a>)</dd>
       {% endif %}
       <dt>Based on</dt>
-      <dd>{{dmp.package.name}}, {{dmp.package.version}}</dd>
+      <dd>{{dmp.package.name}}, {{dmp.package.version}} (<span class="package-id"><span class="organization-id">{{dmp.package.organizationId}}</span>:<span class="km-id">{{dmp.package.kmId}}</span>:<span class="version">{{dmp.package.version}}</span></span>)</dd>
       {% if dmp.config.levelsEnabled %}
       <dt>Project Phase</dt>
       <dd>{{renderCurrentLevel()}}</dd>


### PR DESCRIPTION
Added in header after KM info (name and version), used monospaced font for this...