### PR TITLE
Fix bad chapter->chapterUuid replacement

### DIFF
--- a/dsw-server/templates/dmp/root.html.j2
+++ b/dsw-server/templates/dmp/root.html.j2
@@ -73,7 +73,7 @@
   </section>
 {%- endmacro -%}
 
-{% macro renderIndications(chaptchapterUuider) -%}
+{% macro renderIndications(chapterUuid) -%}
   <h4>Indications</h4>
   <div class="indications">
     <table>


### PR DESCRIPTION
It really looks like this should be `chapterUuid` instead of `chaptchapterUuider`.